### PR TITLE
Adaptable Controller: instances per-request & takes in request ctx

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/iyobo/amala"
   },
   "scripts": {
-    "install": "npm run build"
+    "install": "npm run build",
     "test": "jest --config jestconfig.json",
     "test:watch": "jest --config jestconfig.json --watch",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/iyobo/amala"
   },
   "scripts": {
+    "install": "npm run build"
     "test": "jest --config jestconfig.json",
     "test:watch": "jest --config jestconfig.json --watch",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "url": "https://github.com/iyobo/amala"
   },
   "scripts": {
-    "install": "npm run build",
     "test": "jest --config jestconfig.json",
     "test:watch": "jest --config jestconfig.json --watch",
     "build": "tsc",

--- a/src/util/generateRoutes.ts
+++ b/src/util/generateRoutes.ts
@@ -110,8 +110,6 @@ async function _determineArgument(
   return values;
 }
 
-const controllerInstancesForBinding = {};
-
 async function _generateEndPoints(
   router,
   options: AmalaOptions,
@@ -121,9 +119,6 @@ async function _generateEndPoints(
 ) {
   const actions = controller.actions;
   const controllerInstanceName = controller.class.name + '__' + controller.path;
-  if (!controllerInstancesForBinding[controllerInstanceName]) {
-    controllerInstancesForBinding[controllerInstanceName] = new controller.class();
-  }
 
   let deprecationMessage = '';
   if (
@@ -210,11 +205,14 @@ async function _generateEndPoints(
 
         // run target endpoint handler
         // ctx.body = await action.target(...targetArguments);
-
+        
+        // Each request will create a new controller with the ctx passes as constuctor argument
+        const controllerInstance = new controller.class(ctx);
+        
         // bind to controller instance to allow for "this" within class when
         // accessing other class actions. e.g this.getOne
         ctx.body = await action.target
-          .bind(controllerInstancesForBinding[controllerInstanceName])(...targetArguments);
+          .bind(controllerInstance)(...targetArguments);
 
       });
 


### PR DESCRIPTION
Each request instantiates a new instance of the controller and passes in the koa request context as a constructor parameter. This way we can do more with controllers such as setup dependency injection containers (and other neat things) with very minimal changes to this repository.