### PR TITLE
Teach Amala features with contextual code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,4 +9,4 @@
 
 ## Documentation examples
 
-- Keep every TypeScript code fence in the README and current documentation grounded in a `bootstrapControllers()` call. Prefer a complete small application or show the option being explained inside its bootstrap call; do not publish isolated controller, decorator, or configuration fragments.
+- Keep every TypeScript example group in the README and current documentation grounded in a `bootstrapControllers()` call. A single code fence should include its own bootstrap context. A multi-file tab group may lead with the file that best explains the concept and place bootstrap in an adjacent `main.ts` tab; do not publish isolated controller, decorator, or configuration fragments without that visible connection.

--- a/docs/DESIGN_BRIEF.md
+++ b/docs/DESIGN_BRIEF.md
@@ -10,13 +10,13 @@ Help a TypeScript/Koa developer recognize Amala 13 as the small, type-safe layer
 2. One primary action for v13 setup and a secondary migration action for existing users.
 3. A realistic typed-context example, followed by the familiar controller model.
 4. A compact explanation of what changed, what remains application-owned, and why that keeps Amala small.
-5. Concise capability cards for routing, validation, OpenAPI, and framework control.
+5. Illustrated capability cards that pair each routing, input, validation, and OpenAPI claim with recognizable Amala code and its bootstrap context.
 6. Clear next steps for installation, migration, configuration, and security.
 
 ## States and responsive behavior
 
-- Desktop: asymmetric two-column hero, layered code panel, release strip, and four-column capability grid.
-- Tablet and mobile: single-column flow, full-width actions, horizontally scrollable code, usable version selector, and no clipped navigation or content.
+- Desktop: asymmetric two-column hero, layered code panel, release strip, and a two-column capability grid with stable code-card geometry.
+- Tablet and mobile: single-column flow, full-width actions, horizontally scrollable code inside its card, usable version selector, and no clipped navigation or page content.
 - Light and dark themes: preserve contrast and hierarchy using shared color tokens.
 - Reduced motion: no required animation; hover effects remain cosmetic.
 
@@ -25,6 +25,7 @@ Help a TypeScript/Koa developer recognize Amala 13 as the small, type-safe layer
 - Use sentence case and current TypeScript terminology.
 - Lead with “Keep Koa. Add a contract.” and avoid implying runtime enforcement from TypeScript generics.
 - Avoid unsupported performance or scalability claims.
+- Pair every technical capability claim with code or another useful illustration; do not use feature prose merely to fill a card.
 - Identify what Amala provides and what applications must provide, especially authentication and authorization.
 - Every setup or error path should point to a concrete next action.
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -3,6 +3,9 @@ sidebar_position: 2
 sidebar_label: Getting started
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Getting started
 
 This guide creates a small versioned API with one controller and a validated endpoint.
@@ -55,18 +58,29 @@ These settings select TypeScript's legacy decorator implementation. Standard dec
 
 ## Create and bootstrap the app
 
-Create `src/main.ts`. The controller and the call that turns it into a running Koa application live together here so the complete route is visible:
+Start with the controller, then open the `main.ts` tab to see how it becomes a running application:
+
+<Tabs groupId="first-app">
+  <TabItem value="controller" label="HealthController.ts" default>
 
 ```typescript
-import {bootstrapControllers, Controller, Get} from 'amala';
+import {Controller, Get} from 'amala';
 
 @Controller('/health')
-class HealthController {
+export class HealthController {
   @Get('/')
   status() {
     return {status: 'ok'};
   }
 }
+```
+
+  </TabItem>
+  <TabItem value="main" label="main.ts">
+
+```typescript
+import {bootstrapControllers} from 'amala';
+import {HealthController} from './controllers/HealthController';
 
 async function start() {
   const {app} = await bootstrapControllers({
@@ -82,6 +96,9 @@ async function start() {
 
 void start();
 ```
+
+  </TabItem>
+</Tabs>
 
 Compile and run the application with the scripts used by your project. Request:
 
@@ -144,10 +161,12 @@ These generics catch accidental undeclared context access at compile time. They 
 
 Create `src/controllers/UserController.ts`:
 
+<Tabs groupId="validation-example">
+  <TabItem value="controller" label="UserController.ts" default>
+
 ```typescript
 import {
   Body,
-  bootstrapControllers,
   Controller,
   IsEmail,
   IsString,
@@ -156,10 +175,10 @@ import {
 
 class CreateUserInput {
   @IsEmail()
-  email: string;
+  email!: string;
 
   @IsString()
-  displayName: string;
+  displayName!: string;
 }
 
 @Controller('/users')
@@ -169,6 +188,15 @@ export class UserController {
     return input;
   }
 }
+```
+
+  </TabItem>
+  <TabItem value="main" label="main.ts">
+
+```typescript
+import {bootstrapControllers} from 'amala';
+import {HealthController} from './controllers/HealthController';
+import {UserController} from './controllers/UserController';
 
 async function start() {
   const {app} = await bootstrapControllers({
@@ -184,6 +212,9 @@ async function start() {
 
 void start();
 ```
+
+  </TabItem>
+</Tabs>
 
 Register `UserController` beside `HealthController`. Amala transforms the JSON body into `CreateUserInput`, runs class-validator, and returns `422` when validation fails.
 

--- a/docs/scripts/check-code-examples.mjs
+++ b/docs/scripts/check-code-examples.mjs
@@ -8,7 +8,7 @@ const repositoryDirectory = path.resolve(
   '..'
 );
 const currentDocsDirectory = path.join(repositoryDirectory, 'docs', 'docs');
-const websitePagesDirectory = path.join(repositoryDirectory, 'docs', 'src', 'pages');
+const websiteSourceDirectory = path.join(repositoryDirectory, 'docs', 'src');
 const markdownFiles = [path.join(repositoryDirectory, 'README.md')];
 
 async function collectMarkdownFiles(directory) {
@@ -32,6 +32,18 @@ for (const filePath of markdownFiles) {
   for (const match of source.matchAll(typescriptFence)) {
     if (bootstrapCall.test(match[1])) continue;
 
+    const beforeExample = source.slice(0, match.index);
+    const tabsStart = beforeExample.lastIndexOf('<Tabs');
+    const priorTabsEnd = beforeExample.lastIndexOf('</Tabs>');
+    const tabsEnd = source.indexOf('</Tabs>', match.index);
+    if (
+      tabsStart > priorTabsEnd &&
+      tabsEnd !== -1 &&
+      bootstrapCall.test(source.slice(tabsStart, tabsEnd))
+    ) {
+      continue;
+    }
+
     const line = source.slice(0, match.index).split('\n').length;
     incompleteExamples.push(
       `${path.relative(repositoryDirectory, filePath)}:${line}`
@@ -39,31 +51,37 @@ for (const filePath of markdownFiles) {
   }
 }
 
-if (incompleteExamples.length > 0) {
-  console.error(
-    'Every current TypeScript example must include a bootstrapControllers() call.\n' +
-    incompleteExamples.map(example => `- ${example}`).join('\n')
-  );
-  process.exit(1);
+async function collectJavaScriptFiles(directory) {
+  const entries = await readdir(directory, {withFileTypes: true});
+  const nested = await Promise.all(entries.map(async entry => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return collectJavaScriptFiles(entryPath);
+    return /\.jsx?$/i.test(entry.name) ? [entryPath] : [];
+  }));
+  return nested.flat();
 }
 
-console.log('Documentation example policy passed.');
-
-const websitePages = (await readdir(websitePagesDirectory))
-  .filter(fileName => /\.jsx?$/i.test(fileName))
-  .map(fileName => path.join(websitePagesDirectory, fileName));
-
-for (const filePath of websitePages) {
+for (const filePath of await collectJavaScriptFiles(websiteSourceDirectory)) {
   const source = await readFile(filePath, 'utf8');
   const templates = new Map(
     [...source.matchAll(/const\s+(\w+)\s*=\s*`([\s\S]*?)`;/g)]
       .map(match => [match[1], match[2]])
   );
-  const codeBlock = /<CodeBlock\b[^>]*language=["']typescript["'][^>]*>\s*\{(\w+)\}\s*<\/CodeBlock>/g;
+  const codeBlock = /<CodeBlock\b[^>]*language=["']typescript["'][^>]*>\s*\{([\w.]+)\}\s*<\/CodeBlock>/g;
 
   for (const match of source.matchAll(codeBlock)) {
     const example = templates.get(match[1]);
     if (example && bootstrapCall.test(example)) continue;
+    if (match[1].includes('.')) continue;
+
+    const line = source.slice(0, match.index).split('\n').length;
+    incompleteExamples.push(
+      `${path.relative(repositoryDirectory, filePath)}:${line}`
+    );
+  }
+
+  for (const match of source.matchAll(/\bcode:\s*`([\s\S]*?)`/g)) {
+    if (bootstrapCall.test(match[1])) continue;
 
     const line = source.slice(0, match.index).split('\n').length;
     incompleteExamples.push(
@@ -74,10 +92,10 @@ for (const filePath of websitePages) {
 
 if (incompleteExamples.length > 0) {
   console.error(
-    'Every current TypeScript example must include a bootstrapControllers() call.\n' +
+    'Every current TypeScript example group must include a bootstrapControllers() call.\n' +
     incompleteExamples.map(example => `- ${example}`).join('\n')
   );
   process.exit(1);
 }
 
-console.log('Website example policy passed.');
+console.log('Documentation example-group policy passed.');

--- a/docs/src/components/HomepageFeatures/index.js
+++ b/docs/src/components/HomepageFeatures/index.js
@@ -1,3 +1,4 @@
+import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
@@ -5,22 +6,100 @@ const features = [
   {
     number: '01',
     title: 'Routes that read like code',
-    description: 'Map controller methods to HTTP paths, versions, and middleware without giving up the underlying Koa router.',
+    description: 'A controller prefix and an HTTP decorator become a real Koa route. Bootstrap mounts it and returns the app.',
+    codeTitle: 'GET /v1/users/:id',
+    code: `@Controller('/users')
+class UserController {
+  @Get('/:id')
+  getOne(@Params('id') id: string) {
+    return {id};
+  }
+}
+
+async function main() {
+  const {app} = await bootstrapControllers({
+    controllers: [UserController],
+  });
+  app.listen(3000);
+}
+
+void main();`,
   },
   {
     number: '02',
     title: 'Inputs with a narrow shape',
-    description: 'Inject the specific body, path, query, state, session, or context value each handler actually needs.',
+    description: 'Inject only what a handler needs. The method signature documents the request instead of hiding it in context access.',
+    codeTitle: 'GET /v1/search?q=amala',
+    code: `@Controller('/search')
+class SearchController {
+  @Get('/')
+  find(@Query('q') query?: string) {
+    return {query};
+  }
+}
+
+async function main() {
+  const {app} = await bootstrapControllers({
+    controllers: [SearchController],
+  });
+  app.listen(3000);
+}
+
+void main();`,
   },
   {
     number: '03',
     title: 'Validation at the edge',
-    description: 'Transform decorated TypeScript classes and run class-validator before application logic receives the value.',
+    description: 'A decorated class becomes a runtime request boundary, with strict unknown-field handling selected at bootstrap.',
+    codeTitle: 'POST /v1/users',
+    code: `class CreateUserInput {
+  @IsEmail()
+  email!: string;
+}
+
+@Controller('/users')
+class UserController {
+  @Post('/')
+  create(@Body({required: true}) input: CreateUserInput) {
+    return input;
+  }
+}
+
+async function main() {
+  const {app} = await bootstrapControllers({
+    controllers: [UserController],
+    validatorOptions: {
+      forbidNonWhitelisted: true,
+      whitelist: true,
+    },
+  });
+  app.listen(3000);
+}
+
+void main();`,
   },
   {
     number: '04',
     title: 'An API others can inspect',
-    description: 'Generate an OpenAPI 3 document and Swagger UI from the same metadata that powers the routes.',
+    description: 'Configure the generated OpenAPI document beside the controllers it describes. Swagger stays on the same origin.',
+    codeTitle: 'OpenAPI at /api/docs',
+    code: `async function main() {
+  const {app} = await bootstrapControllers({
+    basePath: '/api',
+    controllers: [UserController],
+    openAPI: {
+      spec: {
+        info: {
+          title: 'Example API',
+          version: '1.0.0',
+        },
+      },
+    },
+  });
+  app.listen(3000);
+}
+
+void main();`,
   },
 ];
 
@@ -40,6 +119,11 @@ export default function HomepageFeatures() {
               <span className={styles.number}>{feature.number}</span>
               <Heading as="h3">{feature.title}</Heading>
               <p>{feature.description}</p>
+              <div className={styles.example}>
+                <CodeBlock language="typescript" title={feature.codeTitle}>
+                  {feature.code}
+                </CodeBlock>
+              </div>
             </article>
           ))}
         </div>

--- a/docs/src/components/HomepageFeatures/styles.module.css
+++ b/docs/src/components/HomepageFeatures/styles.module.css
@@ -28,19 +28,18 @@
 
 .grid {
   display: grid;
-  gap: 1px;
-  grid-template-columns: repeat(4, 1fr);
-  overflow: hidden;
+  gap: 1.25rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .card {
-  border-left: 1px solid var(--amala-border);
-  min-height: 300px;
-  padding: 1.7rem;
-}
-
-.card:first-child {
-  border-left: 0;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--amala-border);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 1.7rem 1.7rem 1.2rem;
 }
 
 .number {
@@ -49,7 +48,7 @@
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0.12em;
-  margin-bottom: 4.5rem;
+  margin-bottom: 2.5rem;
 }
 
 .card h3 {
@@ -64,17 +63,29 @@
   margin: 0;
 }
 
+.example {
+  margin-top: 1.5rem;
+  min-width: 0;
+}
+
+.example :global(.theme-code-block) {
+  border: 1px solid var(--amala-border);
+  box-shadow: none;
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+.example :global(pre) {
+  line-height: 1.45;
+}
+
 @media screen and (max-width: 996px) {
   .heading {
     grid-template-columns: 1fr;
   }
 
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .card:nth-child(3) {
-    border-left: 0;
+  .example :global(.theme-code-block) {
+    font-size: 0.74rem;
   }
 }
 
@@ -87,19 +98,11 @@
     grid-template-columns: 1fr;
   }
 
-  .card,
-  .card:nth-child(3) {
-    border-left: 0;
-    border-top: 1px solid var(--amala-border);
-    min-height: auto;
-    padding: 1.7rem 0;
-  }
-
-  .card:first-child {
-    border-top: 0;
+  .card {
+    padding: 1.4rem 1rem 0.8rem;
   }
 
   .number {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary

- replace text-only landing-page capability cards with real routing, query injection, validation, and OpenAPI examples
- keep `bootstrapControllers()` visible in every landing-page example
- introduce controller-first file tabs in Getting Started, with adjacent `main.ts` bootstrap tabs
- update the documentation policy check to validate complete example groups and embedded website examples
- record the comprehension-first illustration requirement in the design brief

## Verification

- documentation example-group policy passed
- static documentation build passed
- documentation dependency audit passed with only the two reviewed build-only advisories
- desktop and 390x844 mobile visual checks passed with no page-level horizontal overflow
- controller and `main.ts` tabs render and switch correctly

## Versioning

Documentation-only change; the published library artifact is unchanged, so no npm semver bump is required.